### PR TITLE
Fix auto-accept auth for pi 0.63+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A [pi](https://github.com/mariozechner/pi) package that adds a confirmation dial
 
 ## Installation
 
+Requires pi / `@mariozechner/pi-coding-agent` `0.63.0` or newer.
+
 ```bash
 pi install npm:pi-bash-confirm
 ```

--- a/extensions/bash-confirm.ts
+++ b/extensions/bash-confirm.ts
@@ -912,7 +912,11 @@ async function evaluateAutoAcceptCommand(
   }
 
   const modelRef = `${model.provider}/${model.id}`;
-  const apiKey = await ctx.modelRegistry.getApiKey(model);
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok) {
+    return { error: auth.error };
+  }
+
   const timeoutMsRaw = getSetting(settings, "bashConfirm.autoAccept.timeoutMs", 5000);
   const timeoutMsNumber = Number(timeoutMsRaw);
   const timeoutMs = Number.isFinite(timeoutMsNumber)
@@ -930,7 +934,8 @@ async function evaluateAutoAcceptCommand(
         messages: [{ role: "user", content: buildAutoAcceptPrompt(ctx.cwd, command, strictness), timestamp: Date.now() }],
       },
       {
-        apiKey,
+        apiKey: auth.apiKey,
+        headers: auth.headers,
         reasoning: "minimal",
         maxTokens: 120,
         signal: timeoutController.signal,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": ">=0.50.0"
+    "@mariozechner/pi-coding-agent": ">=0.63.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- update auto-accept model auth to use pi's `getApiKeyAndHeaders()` API
- pass request headers through to `completeSimple()`
- document and enforce minimum compatible pi version (`@mariozechner/pi-coding-agent >= 0.63.0`)

## Why
pi 0.63.0 removed `ctx.modelRegistry.getApiKey()` in favor of `getApiKeyAndHeaders()`, which broke the permission/auto-accept model call with:

```
ctx.modelRegistry.getApiKey is not a function
```

## Validation
- `npm run typecheck`
