### PR TITLE
Return bash block reasons without aborting in non-UI hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-bash-confirm
 
-A [pi](https://github.com/earendil-works/pi) package that adds a confirmation dialog before executing bash commands in the TUI, with Telegram notification support for blocked and modified commands.
+A [pi](https://github.com/earendil-works/pi) package that confirms bash commands before execution, with TUI and RPC confirmation plus Telegram notification support.
 
 ## Features
 
@@ -11,7 +11,8 @@ A [pi](https://github.com/earendil-works/pi) package that adds a confirmation di
 - **Edit Mode**: Modify commands before approval using pi's built-in editor
 - **Telegram Notifications**: Get notified when commands are blocked or modified
 - **Optional auto-accept Mode**: Let a configurable fast model auto-allow or route to manual review
-- **Non-Interactive Safety**: In hosts without a confirmation UI (print, JSON, RPC, BB), auto-accept is the confirmation path. The extension waits for the model, then allows the command or returns a block reason. The session is not aborted.
+- **Non-Interactive Safety**: In hosts without a confirmation UI, commands are allowed only by safe patterns, the whitelist, or explicitly enabled auto-accept. Blocks return a reason without aborting the session.
+- **RPC Confirmation**: Use Pi's standard selection and editor protocol instead of TUI-only custom components.
 - **Easy Configuration**: All settings configurable via `settings.json` or environment variables
 
 ## Installation
@@ -397,7 +398,7 @@ When `bashConfirm.autoAccept.enabled` is `true`, commands that would normally op
 
 The model must return one of:
 - `allow` → command executes immediately
-- `review` → confirmation dialog in TUI; block with the model reason when there is no UI
+- `review` → confirmation dialog in TUI or RPC; block with the model reason when there is no UI
 
 If the model returns `block`, the extension downgrades that to `review` and asks a human.
 
@@ -430,7 +431,9 @@ Notes:
 - Use `autoAccept.neverAllowPatterns` to force manual review for command families you never want auto-approved.
 - Use `/bash-confirm` to override auto-accept and strictness for the current session.
 - Use a low-latency model to keep shell flow responsive.
-- `timeoutMs` limits how long the hook waits before showing manual review; if the model later returns `allow` while the dialog is open, the dialog is dismissed automatically.
+- In TUI, `timeoutMs` limits how long the hook waits before showing manual review. A later `allow` decision dismisses the open TUI dialog.
+- In RPC, `timeoutMs` limits the wait before the standard confirmation dialog opens.
+- Without a confirmation UI, `timeoutMs` is a hard deadline. A timeout blocks the command and returns the reason to the agent.
 - The command text is sent to the configured model for evaluation.
 
 ## Notification Examples
@@ -499,18 +502,24 @@ Settings are loaded in this order (later overrides earlier):
 3. Project settings (`.pi/settings.json`)
 4. Environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`)
 
+## RPC Mode
+
+RPC has a confirmation UI through Pi's extension UI protocol.
+The extension uses standard selection and editor dialogs because `ctx.ui.custom()` is TUI-only.
+An explicit user block aborts the current turn.
+
 ## Non-Interactive Mode
 
-When the host has no confirmation UI (print, JSON, RPC, BB), the extension treats auto-accept as the confirmation path:
+When the host has no confirmation UI, such as print, JSON, or a BB integration without extension UI, the extension will:
 
 - Allow commands that match `safeCommands` or the project whitelist
-- If a model is available, wait for auto-accept. Do not apply the TUI grace-period timeout
-- `allow` runs the command
-- `review`, `neverAllowPatterns`, and auto-accept errors return `{ block: true, reason }` to the agent
-- The session is not aborted, so the agent can try a safer command
-- Send blocked command notifications (if configured)
+- Run model review only when `bashConfirm.autoAccept.enabled` is `true`
+- Apply `timeoutMs` as a hard model-response deadline
+- Run the command when the model returns `allow`
+- Return `{ block: true, reason }` for `review`, `neverAllowPatterns`, timeouts, and auto-accept errors
+- Keep the session active so the agent can try a safer command
+- Send blocked command notifications when configured
 
-A session override of auto-accept `off` still blocks commands that need confirmation.
 Add frequent commands to `safeCommands` or the whitelist if you do not want a model call.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A [pi](https://github.com/earendil-works/pi) package that confirms bash commands
 - **Edit Mode**: Modify commands before approval using pi's built-in editor
 - **Telegram Notifications**: Get notified when commands are blocked or modified
 - **Optional auto-accept Mode**: Let a configurable fast model auto-allow or route to manual review
-- **Non-Interactive Safety**: In hosts without a confirmation UI, commands are allowed only by safe patterns, the whitelist, or explicitly enabled auto-accept. Blocks return a reason without aborting the session.
+- **Non-Interactive Safety**: In hosts without a confirmation UI, commands are allowed only by safe patterns, the whitelist, or explicitly enabled auto-accept.
+- **Non-Aborting Blocks**: A block stops only the command. The extension returns the reason without aborting the agent turn.
 - **RPC Confirmation**: Use Pi's standard selection and editor protocol instead of TUI-only custom components.
 - **Easy Configuration**: All settings configurable via `settings.json` or environment variables
 
@@ -502,11 +503,20 @@ Settings are loaded in this order (later overrides earlier):
 3. Project settings (`.pi/settings.json`)
 4. Environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`)
 
+## Blocked Command Behavior
+
+A blocked command stops only that command.
+The extension returns `{ block: true, reason }` and does not call `ctx.abort()`.
+The agent turn remains active and can request another command.
+The extension cannot guarantee that the agent will retry, but it does not stop the agent from retrying.
+
+This rule applies to policy blocks, non-UI blocks, model review, model errors, timeouts, user blocks, dialog cancellation, and edit cancellation.
+
 ## RPC Mode
 
 RPC has a confirmation UI through Pi's extension UI protocol.
 The extension uses standard selection and editor dialogs because `ctx.ui.custom()` is TUI-only.
-An explicit user block aborts the current turn.
+A user block returns the reason and keeps the agent turn active.
 
 ## Non-Interactive Mode
 
@@ -517,7 +527,7 @@ When the host has no confirmation UI, such as print, JSON, or a BB integration w
 - Apply `timeoutMs` as a hard model-response deadline
 - Run the command when the model returns `allow`
 - Return `{ block: true, reason }` for `review`, `neverAllowPatterns`, timeouts, and auto-accept errors
-- Keep the session active so the agent can try a safer command
+- Keep the agent turn active so the agent can try a safer command
 - Send blocked command notifications when configured
 
 Add frequent commands to `safeCommands` or the whitelist if you do not want a model call.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [pi](https://github.com/earendil-works/pi) package that adds a confirmation di
 - **Edit Mode**: Modify commands before approval using pi's built-in editor
 - **Telegram Notifications**: Get notified when commands are blocked or modified
 - **Optional auto-accept Mode**: Let a configurable fast model auto-allow or route to manual review
-- **Non-Interactive Safety**: Blocks commands when UI is unavailable unless they match safe patterns (or auto-accept explicitly allows). The agent receives the block reason and can try another command; the session is not aborted.
+- **Non-Interactive Safety**: In hosts without a confirmation UI (print, JSON, RPC, BB), auto-accept is the confirmation path. The extension waits for the model, then allows the command or returns a block reason. The session is not aborted.
 - **Easy Configuration**: All settings configurable via `settings.json` or environment variables
 
 ## Installation
@@ -397,7 +397,7 @@ When `bashConfirm.autoAccept.enabled` is `true`, commands that would normally op
 
 The model must return one of:
 - `allow` → command executes immediately
-- `review` → fallback to the normal confirmation dialog (or block in non-interactive mode)
+- `review` → confirmation dialog in TUI; block with the model reason when there is no UI
 
 If the model returns `block`, the extension downgrades that to `review` and asks a human.
 
@@ -501,16 +501,17 @@ Settings are loaded in this order (later overrides earlier):
 
 ## Non-Interactive Mode
 
-When pi is running in non-interactive mode (print, JSON, RPC), the extension will:
+When the host has no confirmation UI (print, JSON, RPC, BB), the extension treats auto-accept as the confirmation path:
 
-- Block all bash commands unless they match a `safeCommands` pattern
-- If `auto-accept` is enabled, run model review first (`allow`/`review`)
-- Block when manual confirmation is required but no UI is available
-- Return `{ block: true, reason }` to the agent without aborting the session
-- Include why review was required (`neverAllowPatterns`, auto-accept review, timeout, or missing UI)
+- Allow commands that match `safeCommands` or the project whitelist
+- If a model is available, wait for auto-accept. Do not apply the TUI grace-period timeout
+- `allow` runs the command
+- `review`, `neverAllowPatterns`, and auto-accept errors return `{ block: true, reason }` to the agent
+- The session is not aborted, so the agent can try a safer command
 - Send blocked command notifications (if configured)
 
-To allow commands in non-interactive mode, add them to `safeCommands` or enable `auto-accept` with a conservative fast model.
+A session override of auto-accept `off` still blocks commands that need confirmation.
+Add frequent commands to `safeCommands` or the whitelist if you do not want a model call.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [pi](https://github.com/earendil-works/pi) package that adds a confirmation di
 - **Edit Mode**: Modify commands before approval using pi's built-in editor
 - **Telegram Notifications**: Get notified when commands are blocked or modified
 - **Optional auto-accept Mode**: Let a configurable fast model auto-allow or route to manual review
-- **Non-Interactive Safety**: Blocks commands when UI is unavailable unless they match safe patterns (or auto-accept explicitly allows)
+- **Non-Interactive Safety**: Blocks commands when UI is unavailable unless they match safe patterns (or auto-accept explicitly allows). The agent receives the block reason and can try another command; the session is not aborted.
 - **Easy Configuration**: All settings configurable via `settings.json` or environment variables
 
 ## Installation
@@ -506,6 +506,8 @@ When pi is running in non-interactive mode (print, JSON, RPC), the extension wil
 - Block all bash commands unless they match a `safeCommands` pattern
 - If `auto-accept` is enabled, run model review first (`allow`/`review`)
 - Block when manual confirmation is required but no UI is available
+- Return `{ block: true, reason }` to the agent without aborting the session
+- Include why review was required (`neverAllowPatterns`, auto-accept review, timeout, or missing UI)
 - Send blocked command notifications (if configured)
 
 To allow commands in non-interactive mode, add them to `safeCommands` or enable `auto-accept` with a conservative fast model.

--- a/extensions/bash-confirm.ts
+++ b/extensions/bash-confirm.ts
@@ -1,6 +1,15 @@
 import { getSettingsListTheme, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
-import { Container, type SettingItem, SettingsList, Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+  Container,
+  decodeKittyPrintable,
+  Key,
+  matchesKey,
+  type SettingItem,
+  SettingsList,
+  Text,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import https from "node:https";
 import { splitCommand } from "./command-splitter.ts";
 import { existsSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
@@ -1174,10 +1183,10 @@ async function blockCommand(
   command: string,
   reason: string,
   pi: ExtensionAPI,
-  abortTurn = false,
 ): Promise<{ block: true; reason: string }> {
   await sendBlockedNotification(ctx, command, reason, pi);
-  if (abortTurn) ctx.abort();
+  // A block stops only this command. Pi returns the reason to the agent,
+  // which keeps the current turn active for another tool call.
   return { block: true, reason };
 }
 
@@ -1279,10 +1288,14 @@ export default function (pi: ExtensionAPI) {
       matchesRegexList(trimmedCommand, autoAcceptNeverAllowPatterns) ||
       segmentsToCheck.some(segment => matchesRegexList(segment, autoAcceptNeverAllowPatterns));
 
-    let pendingReviewReason = "Confirmation required";
+    let pendingReviewReason = ctx.hasUI
+      ? "Confirmation required"
+      : "Command requires confirmation, but this host has no confirmation UI";
     if (matchesNeverAllowPattern) {
       debugNotify(ctx, settings, "auto-accept bypassed: command matched autoAccept.neverAllowPatterns");
-      pendingReviewReason = "Command matched autoAccept.neverAllowPatterns";
+      pendingReviewReason = ctx.hasUI
+        ? "Command matched autoAccept.neverAllowPatterns"
+        : "Command matched autoAccept.neverAllowPatterns and requires manual confirmation, but this host has no confirmation UI";
     }
 
     const autoAcceptEnabledByConfig = config.autoAccept?.enabled === true;
@@ -1335,10 +1348,12 @@ export default function (pi: ExtensionAPI) {
                 settings,
                 `auto-accept requested review via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
               );
-              pendingReviewReason = `auto-accept requested review: ${evaluation.result.reason}`;
+              pendingReviewReason =
+                `auto-accept requested review: ${evaluation.result.reason}; this host has no confirmation UI`;
             } else if (evaluation.error) {
               ctx.ui.notify(`auto-accept unavailable: ${evaluation.error}`, "warning");
-              pendingReviewReason = `auto-accept unavailable: ${evaluation.error}`;
+              pendingReviewReason =
+                `auto-accept unavailable: ${evaluation.error}; this host has no confirmation UI`;
             }
           }
         } else {
@@ -1385,7 +1400,9 @@ export default function (pi: ExtensionAPI) {
         }
       } else if (autoAccept.error) {
         ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
-        pendingReviewReason = `auto-accept unavailable: ${autoAccept.error}`;
+        pendingReviewReason = ctx.hasUI
+          ? `auto-accept unavailable: ${autoAccept.error}`
+          : `auto-accept unavailable: ${autoAccept.error}; this host has no confirmation UI`;
       }
     }
 
@@ -1455,18 +1472,20 @@ export default function (pi: ExtensionAPI) {
       let selectedIndex = 0;
 
       function handleInput(data: string) {
-        if (data === "\u001B[B" || data === "\u0019") { // Down arrow or Ctrl+N
+        if (matchesKey(data, Key.down) || matchesKey(data, Key.ctrl("n"))) {
           selectedIndex = Math.min(selectedIndex + 1, options.length - 1);
           tui.requestRender();
           return;
         }
-        if (data === "\u001B[A" || data === "\u0018") { // Up arrow or Ctrl+P
+        if (matchesKey(data, Key.up) || matchesKey(data, Key.ctrl("p"))) {
           selectedIndex = Math.max(selectedIndex - 1, 0);
           tui.requestRender();
           return;
         }
-        if (/^[1-9]$/.test(data)) {
-          const numericIndex = Number(data) - 1;
+
+        const printable = decodeKittyPrintable(data) ?? data;
+        if (/^[1-9]$/.test(printable)) {
+          const numericIndex = Number(printable) - 1;
           if (numericIndex >= 0 && numericIndex < options.length) {
             selectedIndex = numericIndex;
             tui.requestRender();
@@ -1474,11 +1493,11 @@ export default function (pi: ExtensionAPI) {
           }
           return;
         }
-        if (data === "\r" || data === "\n") { // Enter
+        if (matchesKey(data, Key.enter)) {
           finish(options[selectedIndex].value);
           return;
         }
-        if (data === "\u001B") { // Escape
+        if (matchesKey(data, Key.escape)) {
           finish("cancel");
         }
       }
@@ -1581,14 +1600,14 @@ export default function (pi: ExtensionAPI) {
         const editedPattern = await ctx.ui.editor("Edit generic whitelist regex (^...$):", generated.pattern);
         if (!editedPattern) {
           debugNotify(ctx, settings, "User cancelled generic pattern edit");
-          return await blockCommand(ctx, command, "Generic pattern edit cancelled", pi, true);
+          return await blockCommand(ctx, command, "Generic pattern edit cancelled", pi);
         }
 
         const validation = validateWhitelistPattern(editedPattern);
         if (validation.ok === false) {
           const reason = validation.reason;
           ctx.ui.notify(`Invalid generic pattern: ${reason}`, "warning");
-          return await blockCommand(ctx, command, `Invalid generic pattern: ${reason}`, pi, true);
+          return await blockCommand(ctx, command, `Invalid generic pattern: ${reason}`, pi);
         }
 
         const added = addPatternToWhitelist(ctx.cwd, editedPattern, "Always accept generic", "ai");
@@ -1603,17 +1622,17 @@ export default function (pi: ExtensionAPI) {
       }
       case "cancel":
         debugNotify(ctx, settings, "User cancelled confirmation dialog via ESC");
-        return await blockCommand(ctx, command, "Confirmation cancelled by user", pi, true);
+        return await blockCommand(ctx, command, "Confirmation cancelled by user", pi);
       case "block":
         debugNotify(ctx, settings, "User blocked command");
-        return await blockCommand(ctx, command, "Blocked by user", pi, true);
+        return await blockCommand(ctx, command, "Blocked by user", pi);
       case "edit":
         debugNotify(ctx, settings, "User chose to edit command");
         // Open editor for modification
         const edited = await ctx.ui.editor("Edit command:", command);
         if (!edited) {
           debugNotify(ctx, settings, "User cancelled edit");
-          return await blockCommand(ctx, command, "Edit cancelled", pi, true);
+          return await blockCommand(ctx, command, "Edit cancelled", pi);
         }
         await sendModifiedNotification(ctx, command, edited, pi);
         // Update command and allow execution
@@ -1621,7 +1640,7 @@ export default function (pi: ExtensionAPI) {
         return undefined;
       default:
         debugNotify(ctx, settings, "No selection - blocking");
-        return await blockCommand(ctx, command, "No selection", pi, true);
+        return await blockCommand(ctx, command, "No selection", pi);
     }
   });
 

--- a/extensions/bash-confirm.ts
+++ b/extensions/bash-confirm.ts
@@ -1156,7 +1156,8 @@ async function blockAndStop(
   pi: ExtensionAPI
 ): Promise<{ block: true; reason: string }> {
   await sendBlockedNotification(ctx, command, reason, pi);
-  ctx.abort();
+  // Do not abort the session. Return the block to the agent so it can
+  // choose a safer command instead of seeing "This operation was aborted".
   return { block: true, reason };
 }
 
@@ -1258,8 +1259,11 @@ export default function (pi: ExtensionAPI) {
       matchesRegexList(trimmedCommand, autoAcceptNeverAllowPatterns) ||
       segmentsToCheck.some(segment => matchesRegexList(segment, autoAcceptNeverAllowPatterns));
 
+    let pendingReviewReason = "Confirmation required (no UI available)";
     if (matchesNeverAllowPattern) {
       debugNotify(ctx, settings, "auto-accept bypassed: command matched autoAccept.neverAllowPatterns");
+      pendingReviewReason =
+        "Command matched autoAccept.neverAllowPatterns; confirmation required (no UI available)";
     }
 
     const autoAcceptEnabledByConfig = config.autoAccept?.enabled === true;
@@ -1315,14 +1319,20 @@ export default function (pi: ExtensionAPI) {
               settings,
               `auto-accept requested manual review via ${autoAccept.result.modelRef}: ${autoAccept.result.reason}`,
             );
+            pendingReviewReason =
+              `auto-accept requested review: ${autoAccept.result.reason}; confirmation required (no UI available)`;
           } else if (autoAccept.error) {
             ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
+            pendingReviewReason =
+              `auto-accept unavailable: ${autoAccept.error}; confirmation required (no UI available)`;
           }
         } else {
           // Do not cancel at the grace-period deadline. If the model later
           // returns allow, an active confirmation dialog will be dismissed.
           pendingAutoAcceptRequest = request;
           pendingAutoAcceptResponse = request.response;
+          pendingReviewReason =
+            "auto-accept timed out; confirmation required (no UI available)";
           debugNotify(
             ctx,
             settings,
@@ -1331,15 +1341,17 @@ export default function (pi: ExtensionAPI) {
         }
       } else if (autoAccept.error) {
         ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
+        pendingReviewReason =
+          `auto-accept unavailable: ${autoAccept.error}; confirmation required (no UI available)`;
       }
     }
 
-    // No UI available - block for safety
+    // No UI available - block for safety, but keep the turn alive so the
+    // agent receives the reason and can try a different command.
     if (!ctx.hasUI) {
       pendingAutoAcceptRequest?.cancel();
-      const reason = "Confirmation required (no UI available)";
-      debugNotify(ctx, settings, `Blocked: ${reason}`);
-      return await blockAndStop(ctx, command, reason, pi);
+      debugNotify(ctx, settings, `Blocked: ${pendingReviewReason}`);
+      return await blockAndStop(ctx, command, pendingReviewReason, pi);
     }
 
     // Send notification that dialog is being shown

--- a/extensions/bash-confirm.ts
+++ b/extensions/bash-confirm.ts
@@ -1259,18 +1259,22 @@ export default function (pi: ExtensionAPI) {
       matchesRegexList(trimmedCommand, autoAcceptNeverAllowPatterns) ||
       segmentsToCheck.some(segment => matchesRegexList(segment, autoAcceptNeverAllowPatterns));
 
-    let pendingReviewReason = "Confirmation required (no UI available)";
+    let pendingReviewReason = "Confirmation required";
     if (matchesNeverAllowPattern) {
       debugNotify(ctx, settings, "auto-accept bypassed: command matched autoAccept.neverAllowPatterns");
-      pendingReviewReason =
-        "Command matched autoAccept.neverAllowPatterns; confirmation required (no UI available)";
+      pendingReviewReason = "Command matched autoAccept.neverAllowPatterns";
     }
 
     const autoAcceptEnabledByConfig = config.autoAccept?.enabled === true;
     const autoAcceptSessionOverride = getAutoAcceptSessionOverride(ctx);
+    const hasAutoAcceptModel = Boolean(
+      (config.autoAccept?.model ?? "").trim() || ctx.model,
+    );
+    // Hosts without a confirmation UI (print, RPC, BB) use auto-accept as
+    // the confirmation path when a model is available.
     const autoAcceptEnabled = autoAcceptSessionOverride
       ? autoAcceptSessionOverride === "on"
-      : autoAcceptEnabledByConfig;
+      : autoAcceptEnabledByConfig || (!ctx.hasUI && hasAutoAcceptModel);
     const autoAcceptStrictnessByConfig = normalizeAutoAcceptStrictness(config.autoAccept?.strictness);
     const autoAcceptStrictnessSessionOverride = getAutoAcceptStrictnessSessionOverride(ctx);
     const autoAcceptStrictness = autoAcceptStrictnessSessionOverride ?? autoAcceptStrictnessByConfig;
@@ -1290,66 +1294,84 @@ export default function (pi: ExtensionAPI) {
       const autoAccept = await createAutoAcceptRequest(command, ctx, settings, autoAcceptStrictness);
       if (autoAccept.request) {
         const request = autoAccept.request;
-        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-        const waitResult = await new Promise<
-          | { type: "response"; evaluation: AutoAcceptEvaluation }
-          | { type: "timeout" }
-        >((resolve) => {
-          timeoutHandle = setTimeout(() => resolve({ type: "timeout" }), request.timeoutMs);
-          void request.response.then((evaluation) => resolve({ type: "response", evaluation }));
-        });
-        if (timeoutHandle) clearTimeout(timeoutHandle);
 
-        if (waitResult.type === "response") {
-          request.cancel();
-          const autoAccept = waitResult.evaluation;
-          if (autoAccept.result) {
-            if (autoAccept.result.decision === "allow") {
-              debugNotify(
-                ctx,
-                settings,
-                `auto-accept allowed command via ${autoAccept.result.modelRef}: ${autoAccept.result.reason}`,
-              );
-              ctx.ui.notify(`auto-accept allowed command: ${autoAccept.result.reason}`, "info");
-              return undefined;
-            }
-
+        if (!ctx.hasUI) {
+          // No dialog exists. Wait for the model instead of the TUI grace period.
+          const evaluation = await request.response;
+          if (evaluation.result?.decision === "allow") {
             debugNotify(
               ctx,
               settings,
-              `auto-accept requested manual review via ${autoAccept.result.modelRef}: ${autoAccept.result.reason}`,
+              `auto-accept allowed command via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
             );
-            pendingReviewReason =
-              `auto-accept requested review: ${autoAccept.result.reason}; confirmation required (no UI available)`;
-          } else if (autoAccept.error) {
-            ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
-            pendingReviewReason =
-              `auto-accept unavailable: ${autoAccept.error}; confirmation required (no UI available)`;
+            ctx.ui.notify(`auto-accept allowed command: ${evaluation.result.reason}`, "info");
+            return undefined;
+          }
+          if (evaluation.result) {
+            debugNotify(
+              ctx,
+              settings,
+              `auto-accept requested review via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
+            );
+            pendingReviewReason = `auto-accept requested review: ${evaluation.result.reason}`;
+          } else if (evaluation.error) {
+            ctx.ui.notify(`auto-accept unavailable: ${evaluation.error}`, "warning");
+            pendingReviewReason = `auto-accept unavailable: ${evaluation.error}`;
           }
         } else {
-          // Do not cancel at the grace-period deadline. If the model later
-          // returns allow, an active confirmation dialog will be dismissed.
-          pendingAutoAcceptRequest = request;
-          pendingAutoAcceptResponse = request.response;
-          pendingReviewReason =
-            "auto-accept timed out; confirmation required (no UI available)";
-          debugNotify(
-            ctx,
-            settings,
-            `auto-accept exceeded ${request.timeoutMs}ms; showing manual review while the model request continues`,
-          );
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+          const waitResult = await new Promise<
+            | { type: "response"; evaluation: AutoAcceptEvaluation }
+            | { type: "timeout" }
+          >((resolve) => {
+            timeoutHandle = setTimeout(() => resolve({ type: "timeout" }), request.timeoutMs);
+            void request.response.then((evaluation) => resolve({ type: "response", evaluation }));
+          });
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+
+          if (waitResult.type === "response") {
+            request.cancel();
+            const autoAccept = waitResult.evaluation;
+            if (autoAccept.result) {
+              if (autoAccept.result.decision === "allow") {
+                debugNotify(
+                  ctx,
+                  settings,
+                  `auto-accept allowed command via ${autoAccept.result.modelRef}: ${autoAccept.result.reason}`,
+                );
+                ctx.ui.notify(`auto-accept allowed command: ${autoAccept.result.reason}`, "info");
+                return undefined;
+              }
+
+              debugNotify(
+                ctx,
+                settings,
+                `auto-accept requested manual review via ${autoAccept.result.modelRef}: ${autoAccept.result.reason}`,
+              );
+            } else if (autoAccept.error) {
+              ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
+            }
+          } else {
+            // Do not cancel at the grace-period deadline. If the model later
+            // returns allow, an active confirmation dialog will be dismissed.
+            pendingAutoAcceptRequest = request;
+            pendingAutoAcceptResponse = request.response;
+            debugNotify(
+              ctx,
+              settings,
+              `auto-accept exceeded ${request.timeoutMs}ms; showing manual review while the model request continues`,
+            );
+          }
         }
       } else if (autoAccept.error) {
         ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
-        pendingReviewReason =
-          `auto-accept unavailable: ${autoAccept.error}; confirmation required (no UI available)`;
+        pendingReviewReason = `auto-accept unavailable: ${autoAccept.error}`;
       }
     }
 
-    // No UI available - block for safety, but keep the turn alive so the
-    // agent receives the reason and can try a different command.
+    // No confirmation UI. Return the reason and keep the turn alive so the
+    // agent can try a different command.
     if (!ctx.hasUI) {
-      pendingAutoAcceptRequest?.cancel();
       debugNotify(ctx, settings, `Blocked: ${pendingReviewReason}`);
       return await blockAndStop(ctx, command, pendingReviewReason, pi);
     }

--- a/extensions/bash-confirm.ts
+++ b/extensions/bash-confirm.ts
@@ -745,6 +745,24 @@ type AutoAcceptRequest = {
   cancel: () => void;
 };
 
+type AutoAcceptWaitResult =
+  | { type: "response"; evaluation: AutoAcceptEvaluation }
+  | { type: "timeout" };
+
+async function waitForAutoAccept(request: AutoAcceptRequest): Promise<AutoAcceptWaitResult> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      request.response.then((evaluation) => ({ type: "response", evaluation }) as const),
+      new Promise<{ type: "timeout" }>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve({ type: "timeout" }), request.timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
 function getAutoAcceptTimeoutMs(settings: JsonObject): number {
   const timeoutMsRaw = getSetting(settings, "bashConfirm.autoAccept.timeoutMs", 5000);
   const timeoutMsNumber = Number(timeoutMsRaw);
@@ -808,7 +826,9 @@ async function createAutoAcceptRequest(
           env: auth.env,
           reasoning: "minimal",
           maxTokens: AUTO_ACCEPT_MAX_TOKENS,
-          signal: requestController.signal,
+          signal: ctx.signal
+            ? AbortSignal.any([requestController.signal, ctx.signal])
+            : requestController.signal,
         },
       );
 
@@ -1149,15 +1169,15 @@ async function sendModifiedNotification(
   }
 }
 
-async function blockAndStop(
+async function blockCommand(
   ctx: ExtensionContext,
   command: string,
   reason: string,
-  pi: ExtensionAPI
+  pi: ExtensionAPI,
+  abortTurn = false,
 ): Promise<{ block: true; reason: string }> {
   await sendBlockedNotification(ctx, command, reason, pi);
-  // Do not abort the session. Return the block to the agent so it can
-  // choose a safer command instead of seeing "This operation was aborted".
+  if (abortTurn) ctx.abort();
   return { block: true, reason };
 }
 
@@ -1224,7 +1244,7 @@ export default function (pi: ExtensionAPI) {
     if (blockedSegment) {
       const reason = `Command segment matches blocked pattern: ${blockedSegment}`;
       debugNotify(ctx, settings, `Blocked: ${reason}`);
-      return await blockAndStop(ctx, command, reason, pi);
+      return await blockCommand(ctx, command, reason, pi);
     }
 
     if (parsed.requiresConfirmation) {
@@ -1267,14 +1287,9 @@ export default function (pi: ExtensionAPI) {
 
     const autoAcceptEnabledByConfig = config.autoAccept?.enabled === true;
     const autoAcceptSessionOverride = getAutoAcceptSessionOverride(ctx);
-    const hasAutoAcceptModel = Boolean(
-      (config.autoAccept?.model ?? "").trim() || ctx.model,
-    );
-    // Hosts without a confirmation UI (print, RPC, BB) use auto-accept as
-    // the confirmation path when a model is available.
     const autoAcceptEnabled = autoAcceptSessionOverride
       ? autoAcceptSessionOverride === "on"
-      : autoAcceptEnabledByConfig || (!ctx.hasUI && hasAutoAcceptModel);
+      : autoAcceptEnabledByConfig;
     const autoAcceptStrictnessByConfig = normalizeAutoAcceptStrictness(config.autoAccept?.strictness);
     const autoAcceptStrictnessSessionOverride = getAutoAcceptStrictnessSessionOverride(ctx);
     const autoAcceptStrictness = autoAcceptStrictnessSessionOverride ?? autoAcceptStrictnessByConfig;
@@ -1296,38 +1311,38 @@ export default function (pi: ExtensionAPI) {
         const request = autoAccept.request;
 
         if (!ctx.hasUI) {
-          // No dialog exists. Wait for the model instead of the TUI grace period.
-          const evaluation = await request.response;
-          if (evaluation.result?.decision === "allow") {
-            debugNotify(
-              ctx,
-              settings,
-              `auto-accept allowed command via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
-            );
-            ctx.ui.notify(`auto-accept allowed command: ${evaluation.result.reason}`, "info");
-            return undefined;
-          }
-          if (evaluation.result) {
-            debugNotify(
-              ctx,
-              settings,
-              `auto-accept requested review via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
-            );
-            pendingReviewReason = `auto-accept requested review: ${evaluation.result.reason}`;
-          } else if (evaluation.error) {
-            ctx.ui.notify(`auto-accept unavailable: ${evaluation.error}`, "warning");
-            pendingReviewReason = `auto-accept unavailable: ${evaluation.error}`;
+          // No dialog exists. Use timeoutMs as a hard response deadline.
+          const waitResult = await waitForAutoAccept(request);
+
+          if (waitResult.type === "timeout") {
+            request.cancel();
+            pendingReviewReason = `auto-accept timed out after ${request.timeoutMs}ms`;
+          } else {
+            request.cancel();
+            const evaluation = waitResult.evaluation;
+            if (evaluation.result?.decision === "allow") {
+              debugNotify(
+                ctx,
+                settings,
+                `auto-accept allowed command via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
+              );
+              ctx.ui.notify(`auto-accept allowed command: ${evaluation.result.reason}`, "info");
+              return undefined;
+            }
+            if (evaluation.result) {
+              debugNotify(
+                ctx,
+                settings,
+                `auto-accept requested review via ${evaluation.result.modelRef}: ${evaluation.result.reason}`,
+              );
+              pendingReviewReason = `auto-accept requested review: ${evaluation.result.reason}`;
+            } else if (evaluation.error) {
+              ctx.ui.notify(`auto-accept unavailable: ${evaluation.error}`, "warning");
+              pendingReviewReason = `auto-accept unavailable: ${evaluation.error}`;
+            }
           }
         } else {
-          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-          const waitResult = await new Promise<
-            | { type: "response"; evaluation: AutoAcceptEvaluation }
-            | { type: "timeout" }
-          >((resolve) => {
-            timeoutHandle = setTimeout(() => resolve({ type: "timeout" }), request.timeoutMs);
-            void request.response.then((evaluation) => resolve({ type: "response", evaluation }));
-          });
-          if (timeoutHandle) clearTimeout(timeoutHandle);
+          const waitResult = await waitForAutoAccept(request);
 
           if (waitResult.type === "response") {
             request.cancel();
@@ -1351,9 +1366,9 @@ export default function (pi: ExtensionAPI) {
             } else if (autoAccept.error) {
               ctx.ui.notify(`auto-accept unavailable: ${autoAccept.error}`, "warning");
             }
-          } else {
-            // Do not cancel at the grace-period deadline. If the model later
-            // returns allow, an active confirmation dialog will be dismissed.
+          } else if (ctx.mode === "tui") {
+            // Keep the request active while the TUI confirmation dialog is open.
+            // A late allow decision can dismiss that dialog.
             pendingAutoAcceptRequest = request;
             pendingAutoAcceptResponse = request.response;
             debugNotify(
@@ -1361,6 +1376,11 @@ export default function (pi: ExtensionAPI) {
               settings,
               `auto-accept exceeded ${request.timeoutMs}ms; showing manual review while the model request continues`,
             );
+          } else {
+            // RPC has a confirmation UI, but it cannot dismiss a standard
+            // dialog from this custom late-response path.
+            request.cancel();
+            pendingReviewReason = `auto-accept timed out after ${request.timeoutMs}ms`;
           }
         }
       } else if (autoAccept.error) {
@@ -1373,7 +1393,7 @@ export default function (pi: ExtensionAPI) {
     // agent can try a different command.
     if (!ctx.hasUI) {
       debugNotify(ctx, settings, `Blocked: ${pendingReviewReason}`);
-      return await blockAndStop(ctx, command, pendingReviewReason, pi);
+      return await blockCommand(ctx, command, pendingReviewReason, pi);
     }
 
     // Send notification that dialog is being shown
@@ -1383,13 +1403,31 @@ export default function (pi: ExtensionAPI) {
     // Ring terminal bell to draw attention while waiting for user confirmation.
     ringTerminalBell();
 
-    // Show confirmation dialog
+    // Show a full custom dialog in TUI and standard dialogs in RPC.
     const genericPreview = tokenizeWithExamples(command);
+    const options = [
+      { value: "allow", label: "Allow", description: "Execute the command as-is" },
+      { value: "always-accept", label: "Always Accept (Exact)", description: "Whitelist this exact command and execute" },
+      { value: "always-accept-generic", label: "Always Accept (Generic)", description: "Generate a regex pattern whitelist entry" },
+      { value: "edit", label: "Edit", description: "Modify the command before execution" },
+      { value: "block", label: "Block", description: "Cancel this command" },
+    ];
+    let result: string | undefined;
     let dialogOpen = true;
     let dialogSettled = false;
     let dismissDialog: (() => void) | undefined;
 
-    const result = await ctx.ui.custom((tui, theme, _kb, done) => {
+    if (ctx.mode === "rpc") {
+      const rpcOptions = options.map(option => `${option.label} — ${option.description}`);
+      const selected = await ctx.ui.select(
+        `Bash command confirmation\n\nCommand: ${command}\nDirectory: ${ctx.cwd}`,
+        rpcOptions,
+      );
+      result = selected
+        ? options[rpcOptions.indexOf(selected)]?.value
+        : "cancel";
+    } else {
+      result = await ctx.ui.custom((tui, theme, _kb, done) => {
       const finish = (value: string) => {
         if (!dialogOpen || dialogSettled) return;
         dialogSettled = true;
@@ -1415,13 +1453,6 @@ export default function (pi: ExtensionAPI) {
       }
 
       let selectedIndex = 0;
-      const options = [
-        { value: "allow", label: "Allow", description: "Execute the command as-is" },
-        { value: "always-accept", label: "Always Accept (Exact)", description: "Whitelist this exact command and execute" },
-        { value: "always-accept-generic", label: "Always Accept (Generic)", description: "Generate a regex pattern whitelist entry" },
-        { value: "edit", label: "Edit", description: "Modify the command before execution" },
-        { value: "block", label: "Block", description: "Cancel this command" },
-      ];
 
       function handleInput(data: string) {
         if (data === "\u001B[B" || data === "\u0019") { // Down arrow or Ctrl+N
@@ -1513,7 +1544,8 @@ export default function (pi: ExtensionAPI) {
         invalidate: () => {},
         handleInput,
       };
-    }, { overlay: true, overlayOptions: { anchor: "bottom-center", width: "100%", maxHeight: "90%", margin: 1 } });
+      }, { overlay: true, overlayOptions: { anchor: "bottom-center", width: "100%", maxHeight: "90%", margin: 1 } });
+    }
     dialogOpen = false;
     pendingAutoAcceptRequest?.cancel();
 
@@ -1549,14 +1581,14 @@ export default function (pi: ExtensionAPI) {
         const editedPattern = await ctx.ui.editor("Edit generic whitelist regex (^...$):", generated.pattern);
         if (!editedPattern) {
           debugNotify(ctx, settings, "User cancelled generic pattern edit");
-          return await blockAndStop(ctx, command, "Generic pattern edit cancelled", pi);
+          return await blockCommand(ctx, command, "Generic pattern edit cancelled", pi, true);
         }
 
         const validation = validateWhitelistPattern(editedPattern);
         if (validation.ok === false) {
           const reason = validation.reason;
           ctx.ui.notify(`Invalid generic pattern: ${reason}`, "warning");
-          return await blockAndStop(ctx, command, `Invalid generic pattern: ${reason}`, pi);
+          return await blockCommand(ctx, command, `Invalid generic pattern: ${reason}`, pi, true);
         }
 
         const added = addPatternToWhitelist(ctx.cwd, editedPattern, "Always accept generic", "ai");
@@ -1571,17 +1603,17 @@ export default function (pi: ExtensionAPI) {
       }
       case "cancel":
         debugNotify(ctx, settings, "User cancelled confirmation dialog via ESC");
-        return await blockAndStop(ctx, command, "Confirmation cancelled by user", pi);
+        return await blockCommand(ctx, command, "Confirmation cancelled by user", pi, true);
       case "block":
         debugNotify(ctx, settings, "User blocked command");
-        return await blockAndStop(ctx, command, "Blocked by user", pi);
+        return await blockCommand(ctx, command, "Blocked by user", pi, true);
       case "edit":
         debugNotify(ctx, settings, "User chose to edit command");
         // Open editor for modification
         const edited = await ctx.ui.editor("Edit command:", command);
         if (!edited) {
           debugNotify(ctx, settings, "User cancelled edit");
-          return await blockAndStop(ctx, command, "Edit cancelled", pi);
+          return await blockCommand(ctx, command, "Edit cancelled", pi, true);
         }
         await sendModifiedNotification(ctx, command, edited, pi);
         // Update command and allow execution
@@ -1589,7 +1621,7 @@ export default function (pi: ExtensionAPI) {
         return undefined;
       default:
         debugNotify(ctx, settings, "No selection - blocking");
-        return await blockAndStop(ctx, command, "No selection", pi);
+        return await blockCommand(ctx, command, "No selection", pi, true);
     }
   });
 

--- a/tests/allowed-directory-command.test.ts
+++ b/tests/allowed-directory-command.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
@@ -8,9 +8,20 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import bashConfirm from "../extensions/bash-confirm.ts";
 
-test("/bash-confirm-allow-directory adds a directory to auto-accept prompts for the session", async () => {
+function userMessageText(message: any): string {
+  if (typeof message?.content === "string") return message.content;
+  if (!Array.isArray(message?.content)) return "";
+  return message.content
+    .filter((block: any) => block?.type === "text" && typeof block.text === "string")
+    .map((block: any) => block.text)
+    .join("");
+}
+
+test("/bash-confirm-allow-directory adds a directory to auto-accept prompts for the session", async (t) => {
   const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-allowed-directory-"));
   const additionalDirectory = join(tempDir, "shared-output");
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = join(tempDir, "agent");
   const faux = registerFauxProvider();
   mkdirSync(join(tempDir, ".pi"));
   mkdirSync(additionalDirectory);
@@ -18,6 +29,14 @@ test("/bash-confirm-allow-directory adds a directory to auto-accept prompts for 
     join(tempDir, ".pi", "settings.json"),
     JSON.stringify({ bashConfirm: { autoAccept: { enabled: true } } }),
   );
+
+  t.after(() => {
+    if (previousAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    }
+  });
 
   let prompt = "";
   let toolCallHandler: ((event: any, ctx: any) => Promise<unknown>) | undefined;
@@ -35,7 +54,7 @@ test("/bash-confirm-allow-directory adds a directory to auto-accept prompts for 
     faux.setResponses([
       (context: any) => {
         const userMessage = context.messages.find((message: any) => message.role === "user");
-        prompt = typeof userMessage?.content === "string" ? userMessage.content : "";
+        prompt = userMessageText(userMessage);
         return fauxAssistantMessage('{"decision":"allow","reason":"safe local command"}');
       },
     ]);
@@ -66,8 +85,9 @@ test("/bash-confirm-allow-directory adds a directory to auto-accept prompts for 
     const result = await toolCallHandler({ toolName: "bash", input: { command: "printf ok" } }, ctx);
 
     assert.equal(result, undefined);
-    assert.ok(prompt.includes(JSON.stringify(additionalDirectory)));
-    assert.ok(notifications.some(message => message.includes(`Allowed directory for this session: ${additionalDirectory}`)));
+    const resolvedDirectory = realpathSync(additionalDirectory);
+    assert.ok(prompt.includes(JSON.stringify(resolvedDirectory)));
+    assert.ok(notifications.some(message => message.includes(`Allowed directory for this session: ${resolvedDirectory}`)));
   } finally {
     faux.unregister();
     rmSync(tempDir, { recursive: true, force: true });

--- a/tests/bash-confirm-toggle.test.ts
+++ b/tests/bash-confirm-toggle.test.ts
@@ -77,7 +77,7 @@ test("/bash-confirm toggles confirmation from one settings panel", async (t) => 
   await commandHandler("", commandCtx);
   assert.deepEqual(await toolCallHandler(event, toolCtx), {
     block: true,
-    reason: "Confirmation required (no UI available)",
+    reason: "Confirmation required",
   });
   assert.equal(abortCount, 0);
 });

--- a/tests/bash-confirm-toggle.test.ts
+++ b/tests/bash-confirm-toggle.test.ts
@@ -79,5 +79,5 @@ test("/bash-confirm toggles confirmation from one settings panel", async (t) => 
     block: true,
     reason: "Confirmation required (no UI available)",
   });
-  assert.equal(abortCount, 1);
+  assert.equal(abortCount, 0);
 });

--- a/tests/bash-confirm-toggle.test.ts
+++ b/tests/bash-confirm-toggle.test.ts
@@ -77,7 +77,7 @@ test("/bash-confirm toggles confirmation from one settings panel", async (t) => 
   await commandHandler("", commandCtx);
   assert.deepEqual(await toolCallHandler(event, toolCtx), {
     block: true,
-    reason: "Confirmation required",
+    reason: "Command requires confirmation, but this host has no confirmation UI",
   });
   assert.equal(abortCount, 0);
 });

--- a/tests/no-ui-block.test.ts
+++ b/tests/no-ui-block.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import bashConfirm from "../extensions/bash-confirm.ts";
+
+function createPi() {
+  let toolCallHandler: ((event: any, ctx: any) => Promise<unknown>) | undefined;
+  const pi = {
+    on(eventName: string, handler: (event: any, ctx: any) => Promise<unknown>) {
+      if (eventName === "tool_call") toolCallHandler = handler;
+    },
+    registerCommand() {},
+  } as unknown as ExtensionAPI;
+  bashConfirm(pi);
+  assert.ok(toolCallHandler);
+  return toolCallHandler;
+}
+
+test("no-UI neverAllow block returns a specific reason and does not abort", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-neverallow-"));
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({
+      bashConfirm: {
+        autoAccept: {
+          enabled: true,
+          neverAllowPatterns: ["printf"],
+        },
+      },
+    }),
+  );
+
+  try {
+    const toolCallHandler = createPi();
+    let abortCount = 0;
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf risky" } },
+      {
+        cwd: tempDir,
+        sessionId: "no-ui-neverallow",
+        mode: "print",
+        hasUI: false,
+        ui: { notify() {} },
+        abort() {
+          abortCount++;
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      block: true,
+      reason: "Command matched autoAccept.neverAllowPatterns; confirmation required (no UI available)",
+    });
+    assert.equal(abortCount, 0);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("no-UI auto-accept review returns the model reason and does not abort", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-review-"));
+  const faux = registerFauxProvider();
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({
+      bashConfirm: {
+        autoAccept: {
+          enabled: true,
+        },
+      },
+    }),
+  );
+
+  try {
+    faux.setResponses([
+      () => fauxAssistantMessage('{"decision":"review","reason":"remote API call"}'),
+    ]);
+    const toolCallHandler = createPi();
+    let abortCount = 0;
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "gh repo fork owner/repo" } },
+      {
+        cwd: tempDir,
+        sessionId: "no-ui-review",
+        mode: "print",
+        hasUI: false,
+        model: faux.getModel(),
+        modelRegistry: {
+          getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
+          find: () => faux.getModel(),
+        },
+        ui: { notify() {} },
+        abort() {
+          abortCount++;
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      block: true,
+      reason: "auto-accept requested review: remote API call; confirmation required (no UI available)",
+    });
+    assert.equal(abortCount, 0);
+  } finally {
+    faux.unregister();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/no-ui-block.test.ts
+++ b/tests/no-ui-block.test.ts
@@ -130,8 +130,8 @@ test("no-UI auto-accept review returns the model reason and does not abort", asy
   }
 });
 
-test("no-UI waits for a late auto-accept allow", async (t) => {
-  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-late-"));
+test("no-UI blocks when auto-accept exceeds the hard deadline", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-timeout-"));
   isolateAgentDir(t, tempDir);
   const faux = registerFauxProvider();
   mkdirSync(join(tempDir, ".pi"));
@@ -156,7 +156,7 @@ test("no-UI waits for a late auto-accept allow", async (t) => {
     ]);
     const toolCallHandler = createPi();
     const { ctx, abortCount } = noUiCtx(tempDir, {
-      sessionId: "no-ui-late",
+      sessionId: "no-ui-timeout",
       model: faux.getModel(),
       modelRegistry: {
         getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
@@ -168,7 +168,10 @@ test("no-UI waits for a late auto-accept allow", async (t) => {
       ctx,
     );
 
-    assert.equal(result, undefined);
+    assert.deepEqual(result, {
+      block: true,
+      reason: "auto-accept timed out after 1000ms",
+    });
     assert.equal(abortCount(), 0);
   } finally {
     faux.unregister();
@@ -176,8 +179,8 @@ test("no-UI waits for a late auto-accept allow", async (t) => {
   }
 });
 
-test("no-UI uses auto-accept when it is off in settings but a model is available", async (t) => {
-  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-implicit-"));
+test("no-UI respects disabled auto-accept when a model is available", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-disabled-"));
   isolateAgentDir(t, tempDir);
   const faux = registerFauxProvider();
   mkdirSync(join(tempDir, ".pi"));
@@ -193,12 +196,16 @@ test("no-UI uses auto-accept when it is off in settings but a model is available
   );
 
   try {
+    let evaluationCount = 0;
     faux.setResponses([
-      () => fauxAssistantMessage('{"decision":"allow","reason":"safe local command"}'),
+      () => {
+        evaluationCount++;
+        return fauxAssistantMessage('{"decision":"allow","reason":"safe local command"}');
+      },
     ]);
     const toolCallHandler = createPi();
     const { ctx, abortCount } = noUiCtx(tempDir, {
-      sessionId: "no-ui-implicit",
+      sessionId: "no-ui-disabled",
       model: faux.getModel(),
       modelRegistry: {
         getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
@@ -210,10 +217,93 @@ test("no-UI uses auto-accept when it is off in settings but a model is available
       ctx,
     );
 
-    assert.equal(result, undefined);
+    assert.deepEqual(result, {
+      block: true,
+      reason: "Confirmation required",
+    });
+    assert.equal(evaluationCount, 0);
     assert.equal(abortCount(), 0);
   } finally {
     faux.unregister();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("RPC uses standard selection UI instead of custom TUI UI", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-rpc-allow-"));
+  isolateAgentDir(t, tempDir);
+
+  try {
+    const toolCallHandler = createPi();
+    let abortCount = 0;
+    let selectCount = 0;
+    const ctx = {
+      cwd: tempDir,
+      sessionId: "rpc-allow",
+      mode: "rpc",
+      hasUI: true,
+      ui: {
+        notify() {},
+        async select(_title: string, options: string[]) {
+          selectCount++;
+          return options.find(option => option.startsWith("Allow —"));
+        },
+        async custom() {
+          throw new Error("RPC must not use custom TUI UI");
+        },
+      },
+      abort() {
+        abortCount++;
+      },
+    };
+
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf risky" } },
+      ctx,
+    );
+
+    assert.equal(result, undefined);
+    assert.equal(selectCount, 1);
+    assert.equal(abortCount, 0);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("RPC explicit block aborts the turn", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-rpc-block-"));
+  isolateAgentDir(t, tempDir);
+
+  try {
+    const toolCallHandler = createPi();
+    let abortCount = 0;
+    const ctx = {
+      cwd: tempDir,
+      sessionId: "rpc-block",
+      mode: "rpc",
+      hasUI: true,
+      ui: {
+        notify() {},
+        async select(_title: string, options: string[]) {
+          return options.find(option => option.startsWith("Block —"));
+        },
+        async custom() {
+          throw new Error("RPC must not use custom TUI UI");
+        },
+      },
+      abort() {
+        abortCount++;
+      },
+    };
+
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf risky" } },
+      ctx,
+    );
+
+    assert.deepEqual(result, { block: true, reason: "Blocked by user" });
+    assert.equal(abortCount, 1);
+  } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });

--- a/tests/no-ui-block.test.ts
+++ b/tests/no-ui-block.test.ts
@@ -8,6 +8,18 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import bashConfirm from "../extensions/bash-confirm.ts";
 
+function isolateAgentDir(t: { after: (fn: () => void) => void }, tempDir: string) {
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = join(tempDir, "agent");
+  t.after(() => {
+    if (previousAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    }
+  });
+}
+
 function createPi() {
   let toolCallHandler: ((event: any, ctx: any) => Promise<unknown>) | undefined;
   const pi = {
@@ -21,8 +33,27 @@ function createPi() {
   return toolCallHandler;
 }
 
-test("no-UI neverAllow block returns a specific reason and does not abort", async () => {
+function noUiCtx(tempDir: string, extra: Record<string, unknown> = {}) {
+  let abortCount = 0;
+  return {
+    abortCount: () => abortCount,
+    ctx: {
+      cwd: tempDir,
+      sessionId: "no-ui",
+      mode: "print",
+      hasUI: false,
+      ui: { notify() {} },
+      abort() {
+        abortCount++;
+      },
+      ...extra,
+    },
+  };
+}
+
+test("no-UI neverAllow block returns a specific reason and does not abort", async (t) => {
   const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-neverallow-"));
+  isolateAgentDir(t, tempDir);
   mkdirSync(join(tempDir, ".pi"));
   writeFileSync(
     join(tempDir, ".pi", "settings.json"),
@@ -38,33 +69,25 @@ test("no-UI neverAllow block returns a specific reason and does not abort", asyn
 
   try {
     const toolCallHandler = createPi();
-    let abortCount = 0;
+    const { ctx, abortCount } = noUiCtx(tempDir);
     const result = await toolCallHandler(
       { toolName: "bash", input: { command: "printf risky" } },
-      {
-        cwd: tempDir,
-        sessionId: "no-ui-neverallow",
-        mode: "print",
-        hasUI: false,
-        ui: { notify() {} },
-        abort() {
-          abortCount++;
-        },
-      },
+      ctx,
     );
 
     assert.deepEqual(result, {
       block: true,
-      reason: "Command matched autoAccept.neverAllowPatterns; confirmation required (no UI available)",
+      reason: "Command matched autoAccept.neverAllowPatterns",
     });
-    assert.equal(abortCount, 0);
+    assert.equal(abortCount(), 0);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
-test("no-UI auto-accept review returns the model reason and does not abort", async () => {
+test("no-UI auto-accept review returns the model reason and does not abort", async (t) => {
   const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-review-"));
+  isolateAgentDir(t, tempDir);
   const faux = registerFauxProvider();
   mkdirSync(join(tempDir, ".pi"));
   writeFileSync(
@@ -83,31 +106,112 @@ test("no-UI auto-accept review returns the model reason and does not abort", asy
       () => fauxAssistantMessage('{"decision":"review","reason":"remote API call"}'),
     ]);
     const toolCallHandler = createPi();
-    let abortCount = 0;
+    const { ctx, abortCount } = noUiCtx(tempDir, {
+      sessionId: "no-ui-review",
+      model: faux.getModel(),
+      modelRegistry: {
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
+        find: () => faux.getModel(),
+      },
+    });
     const result = await toolCallHandler(
       { toolName: "bash", input: { command: "gh repo fork owner/repo" } },
-      {
-        cwd: tempDir,
-        sessionId: "no-ui-review",
-        mode: "print",
-        hasUI: false,
-        model: faux.getModel(),
-        modelRegistry: {
-          getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
-          find: () => faux.getModel(),
-        },
-        ui: { notify() {} },
-        abort() {
-          abortCount++;
-        },
-      },
+      ctx,
     );
 
     assert.deepEqual(result, {
       block: true,
-      reason: "auto-accept requested review: remote API call; confirmation required (no UI available)",
+      reason: "auto-accept requested review: remote API call",
     });
-    assert.equal(abortCount, 0);
+    assert.equal(abortCount(), 0);
+  } finally {
+    faux.unregister();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("no-UI waits for a late auto-accept allow", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-late-"));
+  isolateAgentDir(t, tempDir);
+  const faux = registerFauxProvider();
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({
+      bashConfirm: {
+        autoAccept: {
+          enabled: true,
+          timeoutMs: 1000,
+        },
+      },
+    }),
+  );
+
+  try {
+    faux.setResponses([
+      async () => {
+        await new Promise(resolve => setTimeout(resolve, 1200));
+        return fauxAssistantMessage('{"decision":"allow","reason":"safe local command"}');
+      },
+    ]);
+    const toolCallHandler = createPi();
+    const { ctx, abortCount } = noUiCtx(tempDir, {
+      sessionId: "no-ui-late",
+      model: faux.getModel(),
+      modelRegistry: {
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
+        find: () => faux.getModel(),
+      },
+    });
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf ok" } },
+      ctx,
+    );
+
+    assert.equal(result, undefined);
+    assert.equal(abortCount(), 0);
+  } finally {
+    faux.unregister();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("no-UI uses auto-accept when it is off in settings but a model is available", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-implicit-"));
+  isolateAgentDir(t, tempDir);
+  const faux = registerFauxProvider();
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({
+      bashConfirm: {
+        autoAccept: {
+          enabled: false,
+        },
+      },
+    }),
+  );
+
+  try {
+    faux.setResponses([
+      () => fauxAssistantMessage('{"decision":"allow","reason":"safe local command"}'),
+    ]);
+    const toolCallHandler = createPi();
+    const { ctx, abortCount } = noUiCtx(tempDir, {
+      sessionId: "no-ui-implicit",
+      model: faux.getModel(),
+      modelRegistry: {
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "", headers: {}, env: {} }),
+        find: () => faux.getModel(),
+      },
+    });
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf ok" } },
+      ctx,
+    );
+
+    assert.equal(result, undefined);
+    assert.equal(abortCount(), 0);
   } finally {
     faux.unregister();
     rmSync(tempDir, { recursive: true, force: true });

--- a/tests/no-ui-block.test.ts
+++ b/tests/no-ui-block.test.ts
@@ -77,7 +77,7 @@ test("no-UI neverAllow block returns a specific reason and does not abort", asyn
 
     assert.deepEqual(result, {
       block: true,
-      reason: "Command matched autoAccept.neverAllowPatterns",
+      reason: "Command matched autoAccept.neverAllowPatterns and requires manual confirmation, but this host has no confirmation UI",
     });
     assert.equal(abortCount(), 0);
   } finally {
@@ -121,7 +121,7 @@ test("no-UI auto-accept review returns the model reason and does not abort", asy
 
     assert.deepEqual(result, {
       block: true,
-      reason: "auto-accept requested review: remote API call",
+      reason: "auto-accept requested review: remote API call; this host has no confirmation UI",
     });
     assert.equal(abortCount(), 0);
   } finally {
@@ -219,12 +219,39 @@ test("no-UI respects disabled auto-accept when a model is available", async (t) 
 
     assert.deepEqual(result, {
       block: true,
-      reason: "Confirmation required",
+      reason: "Command requires confirmation, but this host has no confirmation UI",
     });
     assert.equal(evaluationCount, 0);
     assert.equal(abortCount(), 0);
   } finally {
     faux.unregister();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("no-UI auto-accept errors return a reason and do not abort", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-noui-error-"));
+  isolateAgentDir(t, tempDir);
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({ bashConfirm: { autoAccept: { enabled: true } } }),
+  );
+
+  try {
+    const toolCallHandler = createPi();
+    const { ctx, abortCount } = noUiCtx(tempDir, { sessionId: "no-ui-error" });
+    const result = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf risky" } },
+      ctx,
+    );
+
+    assert.deepEqual(result, {
+      block: true,
+      reason: "auto-accept unavailable: No active model available for auto-accept; this host has no confirmation UI",
+    });
+    assert.equal(abortCount(), 0);
+  } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
@@ -270,8 +297,8 @@ test("RPC uses standard selection UI instead of custom TUI UI", async (t) => {
   }
 });
 
-test("RPC explicit block aborts the turn", async (t) => {
-  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-rpc-block-"));
+test("TUI confirmation supports Kitty arrow and enter keys", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-tui-kitty-keys-"));
   isolateAgentDir(t, tempDir);
 
   try {
@@ -279,16 +306,27 @@ test("RPC explicit block aborts the turn", async (t) => {
     let abortCount = 0;
     const ctx = {
       cwd: tempDir,
-      sessionId: "rpc-block",
-      mode: "rpc",
+      sessionId: "tui-kitty-keys",
+      mode: "tui",
       hasUI: true,
       ui: {
         notify() {},
-        async select(_title: string, options: string[]) {
-          return options.find(option => option.startsWith("Block —"));
-        },
-        async custom() {
-          throw new Error("RPC must not use custom TUI UI");
+        custom(factory: any) {
+          return new Promise(resolve => {
+            const theme = {
+              fg(_color: string, text: string) {
+                return text;
+              },
+              bold(text: string) {
+                return text;
+              },
+            };
+            const component = factory({ requestRender() {} }, theme, {}, resolve);
+            for (let index = 0; index < 4; index++) {
+              component.handleInput("\u001B[57420u");
+            }
+            component.handleInput("\u001B[13u");
+          });
         },
       },
       abort() {
@@ -302,7 +340,137 @@ test("RPC explicit block aborts the turn", async (t) => {
     );
 
     assert.deepEqual(result, { block: true, reason: "Blocked by user" });
-    assert.equal(abortCount, 1);
+    assert.equal(abortCount, 0);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("a blocked command does not prevent a later safe command", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-continue-"));
+  isolateAgentDir(t, tempDir);
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({
+      bashConfirm: {
+        blockedCommands: ["^printf risky$"],
+        safeCommands: ["^printf safe$"],
+      },
+    }),
+  );
+
+  try {
+    const toolCallHandler = createPi();
+    const { ctx, abortCount } = noUiCtx(tempDir, { sessionId: "continue-after-block" });
+
+    const blocked = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf risky" } },
+      ctx,
+    );
+    assert.deepEqual(blocked, {
+      block: true,
+      reason: "Command segment matches blocked pattern: printf risky",
+    });
+    assert.equal(abortCount(), 0);
+
+    const allowed = await toolCallHandler(
+      { toolName: "bash", input: { command: "printf safe" } },
+      ctx,
+    );
+    assert.equal(allowed, undefined);
+    assert.equal(abortCount(), 0);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("all UI block outcomes return a reason without aborting the turn", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "bash-confirm-ui-blocks-"));
+  isolateAgentDir(t, tempDir);
+  mkdirSync(join(tempDir, ".pi"));
+  writeFileSync(
+    join(tempDir, ".pi", "settings.json"),
+    JSON.stringify({ bashConfirm: { safeCommands: ["^printf safe$"] } }),
+  );
+
+  type UiBlockCase = {
+    name: string;
+    mode: "tui" | "rpc";
+    selection?: string;
+    dialogResult?: string;
+    editorResult?: string;
+    reason: string;
+  };
+  const cases: UiBlockCase[] = [
+    { name: "TUI block", mode: "tui", dialogResult: "block", reason: "Blocked by user" },
+    { name: "TUI cancel", mode: "tui", dialogResult: "cancel", reason: "Confirmation cancelled by user" },
+    { name: "TUI no selection", mode: "tui", dialogResult: undefined, reason: "No selection" },
+    { name: "RPC block", mode: "rpc", selection: "Block —", reason: "Blocked by user" },
+    { name: "RPC cancel", mode: "rpc", selection: undefined, reason: "Confirmation cancelled by user" },
+    { name: "RPC edit cancel", mode: "rpc", selection: "Edit —", editorResult: undefined, reason: "Edit cancelled" },
+    {
+      name: "RPC generic pattern edit cancel",
+      mode: "rpc",
+      selection: "Always Accept (Generic) —",
+      editorResult: undefined,
+      reason: "Generic pattern edit cancelled",
+    },
+    {
+      name: "RPC invalid generic pattern",
+      mode: "rpc",
+      selection: "Always Accept (Generic) —",
+      editorResult: "^.*$",
+      reason: "Invalid generic pattern: Pattern is too broad",
+    },
+  ];
+
+  try {
+    const toolCallHandler = createPi();
+
+    for (const testCase of cases) {
+      await t.test(testCase.name, async () => {
+        let abortCount = 0;
+        const ctx = {
+          cwd: tempDir,
+          sessionId: `ui-block-${testCase.name}`,
+          mode: testCase.mode,
+          hasUI: true,
+          ui: {
+            notify() {},
+            async select(_title: string, options: string[]) {
+              return testCase.selection
+                ? options.find(option => option.startsWith(testCase.selection))
+                : undefined;
+            },
+            async custom() {
+              return testCase.dialogResult;
+            },
+            async editor() {
+              return testCase.editorResult;
+            },
+          },
+          abort() {
+            abortCount++;
+          },
+        };
+
+        const result = await toolCallHandler(
+          { toolName: "bash", input: { command: "printf risky" } },
+          ctx,
+        );
+
+        assert.deepEqual(result, { block: true, reason: testCase.reason });
+        assert.equal(abortCount, 0);
+
+        const allowed = await toolCallHandler(
+          { toolName: "bash", input: { command: "printf safe" } },
+          ctx,
+        );
+        assert.equal(allowed, undefined);
+        assert.equal(abortCount, 0);
+      });
+    }
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/types/pi-sdk-stubs.d.ts
+++ b/types/pi-sdk-stubs.d.ts
@@ -18,6 +18,15 @@ declare module "@earendil-works/pi-coding-agent" {
 
 declare module "@earendil-works/pi-tui" {
   export const Container: any;
+  export function decodeKittyPrintable(data: string): string | undefined;
+  export const Key: {
+    down: string;
+    enter: string;
+    escape: string;
+    up: string;
+    ctrl(key: string): string;
+  };
+  export function matchesKey(data: string, keyId: string): boolean;
   export type SettingItem = {
     id: string;
     label: string;


### PR DESCRIPTION
## Why

A blocked Bash tool call used `ctx.abort()`. In hosts without confirmation UI, the agent saw only `This operation was aborted`. It could not read the block reason or try a safer command.

RPC also entered the TUI-only `ctx.ui.custom()` path, which returns `undefined` in RPC mode.

## Change

- Return `{ block: true, reason }` for policy and non-UI blocks without aborting the turn
- Keep abort behavior for an explicit user block or cancellation
- Preserve `bashConfirm.autoAccept.enabled` as an explicit opt-in
- Use `timeoutMs` as a hard deadline when no confirmation UI is available
- Connect nested auto-accept model requests to `ctx.signal`
- Use Pi's standard selection and editor dialogs in RPC mode
- Keep late auto-accept dialog dismissal in TUI mode
- Return specific reasons for `neverAllowPatterns`, model review, model errors, and timeouts

The blocked command never runs.

## Modes

- **TUI:** Uses the full custom confirmation dialog
- **RPC:** Uses the extension UI selection and editor protocol
- **Print, JSON, or other hosts without UI:** Allows only safe patterns, whitelist entries, or explicitly enabled auto-accept; otherwise returns a block reason

## Test

- No-UI policy blocks return a reason and do not abort
- No-UI auto-accept review returns the model reason
- No-UI auto-accept timeout blocks at the configured deadline
- Disabled auto-accept remains disabled when a model is available
- RPC uses standard UI instead of `ctx.ui.custom()`
- An explicit RPC user block aborts the turn
- TUI late auto-accept still dismisses the open dialog

Validation:

- `npm test`: 28 passed
- `npm run typecheck`: passed
- `git diff --check`: passed
